### PR TITLE
[MM-14699] Add fs.existsWithDiffExt

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
@@ -179,6 +179,11 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void existsWithDiffExt(String path, Callback callback) {
+        RNFetchBlobFS.existsWithDiffExt(path, callback);
+    }
+
+    @ReactMethod
     public void cp(final String path, final String dest, final Callback callback) {
         threadPool.execute(new Runnable() {
             @Override

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobFS.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobFS.java
@@ -665,10 +665,23 @@ class RNFetchBlobFS {
      */
     static void existsWithDiffExt(String path, Callback callback) {
             File file = new File(path);
-            File directory = new File(file.getParent());
-            String fileNameWithExt = file.getName();
-            String fileName = fileNameWithExt.substring(0, fileNameWithExt.lastIndexOf("."));
-            final Pattern p = Pattern.compile(fileName + "\\.[a-z]{3,4}");
+            String parent = file.getParent();
+            if (parent == null) {
+                callback.invoke("");
+                return;
+            }
+
+            File directory = new File(parent);
+            if (!directory.exists()) {
+                callback.invoke("");
+                return;
+            }
+
+            String filename = file.getName();
+            int extIndex = filename.lastIndexOf(".");
+            filename = extIndex == -1 ? filename : filename.substring(0, extIndex);
+
+            final Pattern p = Pattern.compile(filename + "\\.[a-z]{3,4}");
             File[] files = directory.listFiles(new FileFilter() {
                 @Override
                 public boolean accept(File file) {
@@ -676,11 +689,12 @@ class RNFetchBlobFS {
                 }
             });
 
-            if (files.length != 0) {
-                callback.invoke(files[0].getAbsolutePath());
-            } else {
-                callback.invoke("");
+            String filePath = "";
+            if (files != null && files.length != 0) {
+                filePath = files[0].getAbsolutePath();
             }
+
+            callback.invoke(filePath);
     }
 
     /**

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobFS.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobFS.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 class RNFetchBlobFS {
 
@@ -654,6 +655,32 @@ class RNFetchBlobFS {
             boolean isDir = new File(path).isDirectory();
             callback.invoke(exist, isDir);
         }
+    }
+
+    /**
+     * Check if the file exists with a different extension and, if so,
+     * return the file path.
+     * @param path Path to check
+     * @param callback  JS context callback
+     */
+    static void existsWithDiffExt(String path, Callback callback) {
+            File file = new File(path);
+            File directory = new File(file.getParent());
+            String fileNameWithExt = file.getName();
+            String fileName = fileNameWithExt.substring(0, fileNameWithExt.lastIndexOf("."));
+            final Pattern p = Pattern.compile(fileName + "\\.[a-z]{3,4}");
+            File[] files = directory.listFiles(new FileFilter() {
+                @Override
+                public boolean accept(File file) {
+                    return p.matcher(file.getName()).matches();
+                }
+            });
+
+            if (files.length != 0) {
+                callback.invoke(files[0].getAbsolutePath());
+            } else {
+                callback.invoke("");
+            }
     }
 
     /**

--- a/fs.js
+++ b/fs.js
@@ -335,6 +335,27 @@ function exists(path: string): Promise<boolean> {
 
 }
 
+/**
+ * Check if the file exists with a different extension.
+ * @param  {string} path Path to check
+ * @return {Promise<boolean>}
+ */
+function existsWithDiffExt(path: string): Promise<boolean> {
+  return new Promise((resolve, reject) => {
+    if (typeof path !== 'string') {
+      return reject(addCode('EINVAL', new TypeError('Missing argument "path" ')))
+    }
+    try {
+      RNFetchBlob.existsWithDiffExt(path, (fileWithExt) => {
+        resolve(fileWithExt)
+      })
+    }catch (err){
+      reject(addCode('EUNSPECIFIED', new Error(err)))
+    }
+  })
+
+}
+
 function slice(src: string, dest: string, start: number, end: number): Promise {
   if (typeof src !== 'string' || typeof dest !== 'string') {
     return reject(addCode('EINVAL', new TypeError('Missing argument "src" and/or "destination"')))
@@ -405,6 +426,7 @@ export default {
   readFile,
   hash,
   exists,
+  existsWithDiffExt,
   createFile,
   isDir,
   stat,

--- a/ios/RNFetchBlob/RNFetchBlob.m
+++ b/ios/RNFetchBlob/RNFetchBlob.m
@@ -234,6 +234,11 @@ RCT_EXPORT_METHOD(exists:(NSString *)path callback:(RCTResponseSenderBlock)callb
     [RNFetchBlobFS exists:path callback:callback];
 }
 
+#pragma mark - fs.existsWithDiffExt
+RCT_EXPORT_METHOD(existsWithDiffExt:(NSString *)path callback:(RCTResponseSenderBlock)callback) {
+    [RNFetchBlobFS existsWithDiffExt:path callback:callback];
+}
+
 #pragma mark - fs.writeFile
 RCT_EXPORT_METHOD(writeFile:(NSString *)path encoding:(NSString *)encoding data:(NSString *)data append:(BOOL)append resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {

--- a/ios/RNFetchBlobFS.h
+++ b/ios/RNFetchBlobFS.h
@@ -65,6 +65,7 @@
      rejecter:(RCTPromiseRejectBlock)reject;
 + (NSDictionary *) stat:(NSString *) path error:(NSError **) error;
 + (void) exists:(NSString *) path callback:(RCTResponseSenderBlock)callback;
++ (void) existsWithDiffExt:(NSString *) path callback:(RCTResponseSenderBlock)callback;
 + (void) writeFileArray:(NSString *)path data:(NSArray *)data append:(BOOL)append resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject;
 + (void) writeFile:(NSString *)path encoding:(NSString *)encoding data:(NSString *)data append:(BOOL)append resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject;
 + (void) readFile:(NSString *)path encoding:(NSString *)encoding onComplete:(void (^)(NSData * content, NSString* code, NSString * errMsg))onComplete;

--- a/ios/RNFetchBlobFS.m
+++ b/ios/RNFetchBlobFS.m
@@ -687,15 +687,21 @@ NSMutableDictionary *fileStreams = nil;
 {
     NSFileManager *manager = [NSFileManager defaultManager];
     NSString *directory = [path stringByDeletingLastPathComponent];
-    NSArray *contents = [manager contentsOfDirectoryAtPath:directory error:nil];
-    NSString *fileName = [[path lastPathComponent] stringByDeletingPathExtension];
-    NSString *item;
-    for (item in contents)
-    {
-        NSString *itemName = [[item lastPathComponent] stringByDeletingPathExtension];
-        if ([itemName isEqualToString:fileName]) {
-            callback(@[[directory stringByAppendingPathComponent:item]]);
-            return;
+    BOOL isDir = NO;
+    BOOL exists = NO;
+    exists = [manager fileExistsAtPath:directory isDirectory: &isDir];
+
+    if (exists && isDir) {
+        NSArray *contents = [manager contentsOfDirectoryAtPath:directory error:nil];
+        NSString *fileName = [[path lastPathComponent] stringByDeletingPathExtension];
+        NSString *item;
+        for (item in contents)
+        {
+            NSString *itemName = [[item lastPathComponent] stringByDeletingPathExtension];
+            if ([itemName isEqualToString:fileName]) {
+                callback(@[[directory stringByAppendingPathComponent:item]]);
+                return;
+            }
         }
     }
 

--- a/ios/RNFetchBlobFS.m
+++ b/ios/RNFetchBlobFS.m
@@ -681,6 +681,27 @@ NSMutableDictionary *fileStreams = nil;
     }];
 }
 
+# pragma mark - existsWithDiffExt
+
++ (void) existsWithDiffExt:(NSString *)path  callback:(RCTResponseSenderBlock)callback
+{
+    NSFileManager *manager = [NSFileManager defaultManager];
+    NSString *directory = [path stringByDeletingLastPathComponent];
+    NSArray *contents = [manager contentsOfDirectoryAtPath:directory error:nil];
+    NSString *fileName = [[path lastPathComponent] stringByDeletingPathExtension];
+    NSString *item;
+    for (item in contents)
+    {
+        NSString *itemName = [[item lastPathComponent] stringByDeletingPathExtension];
+        if ([itemName isEqualToString:fileName]) {
+            callback(@[[directory stringByAppendingPathComponent:item]]);
+            return;
+        }
+    }
+
+    callback(@[@""]);
+}
+
 # pragma mark - open file stream
 
 // Create file stream for write data


### PR DESCRIPTION
Because on the mobile app we can only ever pass file paths ending in `.png` to `fs.exists`, we are not able to retrieve files with any other extension from the cache. With the new `fs.existsWithDiffExt`, we can take that same file path and search the file's parent directory for files that match the filename but with a different extension. If there's a match, it returns the first match otherwise an empty string. 