### PR TITLE
MM-15518 If X-Uncompressed-Content-Length header is present in file responses, use that in progress reports

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
@@ -360,6 +360,7 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
                                 extended = new RNFetchBlobFileResp(
                                         RNFetchBlob.RCTContext,
                                         taskId,
+                                        originalResponse.headers(),
                                         originalResponse.body(),
                                         destPath,
                                         options.overwrite);

--- a/ios/RNFetchBlobRequest.m
+++ b/ios/RNFetchBlobRequest.m
@@ -196,6 +196,13 @@ typedef NS_ENUM(NSUInteger, ResponseFormat) {
     expectedBytes = [response expectedContentLength];
     
     NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*)response;
+
+    NSDictionary *headers = [httpResponse allHeaderFields];
+    NSString *uncompressedLength = headers[@"X-Uncompressed-Content-Length"];
+    if (uncompressedLength != (id)[NSNull null] && uncompressedLength.length > 0) {
+        expectedBytes = [uncompressedLength intValue];
+    }
+
     NSInteger statusCode = [(NSHTTPURLResponse *)response statusCode];
     NSString * respType = @"";
     respStatus = statusCode;


### PR DESCRIPTION
#### Summary
If X-Uncompressed-Content-Length header is present in file responses, use that in progress reports. This is needed to handle gzipped responses.

#### Ticket link
https://mattermost.atlassian.net/browse/MM-15518